### PR TITLE
#35 Hotfix : str values for (current implementation of) conditions

### DIFF
--- a/pype/extra_conditions.py
+++ b/pype/extra_conditions.py
@@ -25,8 +25,9 @@ class RegexCondition(AbstractCondition):
             return False
          #DBG
         logger.debug("Value to match : "+ self.__config["value"] + " in ["+str(item.getValue())+"]")
-        logger.debug(" match : " + str(self.__p.match(item.getValue())))
-        return not self.__p.match(item.getValue()) is None
+        result = self.__p.match(str(item.getValue()))
+        logger.debug(" match : " + str(result))
+        return not  result is None
 
     def __validateConfig(self,config):
         if config is None:


### PR DESCRIPTION
AND not evaluating twice just for logging purposes : result stored and
used for returning result and logging
